### PR TITLE
当日のタスク一覧を作成する

### DIFF
--- a/Shared/Extension/Date.swift
+++ b/Shared/Extension/Date.swift
@@ -1,0 +1,26 @@
+//
+//  Date.swift
+//  ToDoApp_SwiftUI (iOS)
+//
+//  Created by IkkiKobayashi on 2021/02/26.
+//
+
+import Foundation
+
+extension Date {
+    // 「時分秒」を切り捨てて今日の日付を作成
+    static var today: Date {
+        let calender = Calendar(identifier: .gregorian)
+        let time = Date()
+        return calender.startOfDay(for: time)
+    }
+    
+    // 「時分秒」を切り捨てて明日の日付を作成
+    static var tomorrow: Date {
+        let calender = Calendar(identifier: .gregorian)
+        guard let tomorrow = calender.date(byAdding: DateComponents(day: 1), to: Date.today) else {
+            return Date.today
+        }
+        return tomorrow
+    }
+}

--- a/Shared/Shape/RoundedCorners.swift
+++ b/Shared/Shape/RoundedCorners.swift
@@ -1,0 +1,57 @@
+//
+//  RoundedCorners.swift
+//  ToDoApp_SwiftUI (iOS)
+//
+//  Created by IkkiKobayashi on 2021/02/26.
+//
+
+import SwiftUI
+
+// viewの形を好きなポイントで角丸にできるShape
+struct RoundedCorners: Shape {
+    var tl: CGFloat = 0.0
+    var tr: CGFloat = 0.0
+    var bl: CGFloat = 0.0
+    var br: CGFloat = 0.0
+    
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        
+        let w = rect.size.width
+        let h = rect.size.height
+        
+        let tr = min(min(self.tr, h/2), w/2)
+        let tl = min(min(self.tl, h/2), w/2)
+        let bl = min(min(self.bl, h/2), w/2)
+        let br = min(min(self.br, h/2), w/2)
+        
+        path.move(to: CGPoint(x: w / 2.0, y: 0))
+        path.addLine(to: CGPoint(x: w - tr, y: 0))
+        path.addArc(center: CGPoint(x: w - tr, y: tr), radius: tr,
+                    startAngle: Angle(degrees: -90), endAngle: Angle(degrees: 0), clockwise: false)
+        path.addLine(to: CGPoint(x: w, y: h - br))
+        path.addArc(center: CGPoint(x: w - br, y: h - br), radius: br,
+                    startAngle: Angle(degrees: 0), endAngle: Angle(degrees: 90), clockwise: false)
+        path.addLine(to: CGPoint(x: bl, y: h))
+        path.addArc(center: CGPoint(x: bl, y: h - bl), radius: bl,
+                    startAngle: Angle(degrees: 90), endAngle: Angle(degrees: 180), clockwise: false)
+        path.addLine(to: CGPoint(x: 0, y: tl))
+        path.addArc(center: CGPoint(x: tl, y: tl), radius: tl,
+                    startAngle: Angle(degrees: 180), endAngle: Angle(degrees: 270), clockwise: false)
+        path.closeSubpath()
+        
+        
+        return path
+    }
+    
+}
+
+#if DEBUG
+struct RoundedCorners_Previews: PreviewProvider {
+    static var previews: some View {
+        RoundedCorners(tl: 30, tr: 30, bl: 30, br: 30).padding()
+            .foregroundColor(.black)
+    }
+}
+#endif
+

--- a/Shared/Views/ToDoList/TodayToDoListView.swift
+++ b/Shared/Views/ToDoList/TodayToDoListView.swift
@@ -1,0 +1,38 @@
+//
+//  TodayTodoListView.swift
+//  ToDoApp_SwiftUI (iOS)
+//
+//  Created by IkkiKobayashi on 2021/02/26.
+//
+
+import SwiftUI
+
+struct TodayTaskListView: View {
+    
+    @FetchRequest(sortDescriptors: [NSSortDescriptor(keyPath: \ToDoEntity.time,
+                                                     ascending: true)],
+                  predicate: NSPredicate(format: "time BETWEEN {%@ , %@}", Date.today as NSDate, Date.tomorrow as NSDate),
+                  animation: .default) var todoList: FetchedResults<ToDoEntity>
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Todays Task")
+                .font(.footnote)
+                .bold()
+                .padding()
+            List(todoList) { todo in
+                TodoDetailCell(todo: todo)
+            }
+        }.background(Color(UIColor.systemBackground))
+        .clipShape(RoundedCorners(tl: 40, tr: 40, bl: 0, br: 0))
+    }
+}
+
+#if DEBUG
+struct TodayTaskListView_Previews: PreviewProvider {
+    static let context = PersistenceController.shared.container.viewContext
+    static var previews: some View {
+        TodayTaskListView().environment(\.managedObjectContext, context)
+    }
+}
+#endif

--- a/ToDoApp_SwiftUI.xcodeproj/project.pbxproj
+++ b/ToDoApp_SwiftUI.xcodeproj/project.pbxproj
@@ -25,6 +25,9 @@
 		CA25AEFD25DC018600A19DE6 /* CheckBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA25AEFC25DC018600A19DE6 /* CheckBox.swift */; };
 		CA2B8DCB25DE9F1400B47EFD /* CategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2B8DCA25DE9F1400B47EFD /* CategoryView.swift */; };
 		CA2B8E1D25E00AEE00B47EFD /* QuickNewTaskCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2B8E1C25E00AEE00B47EFD /* QuickNewTaskCell.swift */; };
+		CA3E2AFE25E90A6E0040083F /* TodayToDoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3E2AFD25E90A6E0040083F /* TodayToDoListView.swift */; };
+		CA3E2B0525E90ACE0040083F /* RoundedCorners.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3E2B0425E90ACE0040083F /* RoundedCorners.swift */; };
+		CA3E2B0F25E90B280040083F /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3E2B0E25E90B280040083F /* Date.swift */; };
 		CA4544A725E28D5E00665DF3 /* ToDoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4544A625E28D5E00665DF3 /* ToDoListView.swift */; };
 		CA4544AE25E28E9500665DF3 /* ToDoDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4544AD25E28E9500665DF3 /* ToDoDetailCell.swift */; };
 		CA4544B425E28F7600665DF3 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4544B325E28F7600665DF3 /* Binding.swift */; };
@@ -74,6 +77,9 @@
 		CA25AEFC25DC018600A19DE6 /* CheckBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckBox.swift; sourceTree = "<group>"; };
 		CA2B8DCA25DE9F1400B47EFD /* CategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryView.swift; sourceTree = "<group>"; };
 		CA2B8E1C25E00AEE00B47EFD /* QuickNewTaskCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickNewTaskCell.swift; sourceTree = "<group>"; };
+		CA3E2AFD25E90A6E0040083F /* TodayToDoListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayToDoListView.swift; sourceTree = "<group>"; };
+		CA3E2B0425E90ACE0040083F /* RoundedCorners.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCorners.swift; sourceTree = "<group>"; };
+		CA3E2B0E25E90B280040083F /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
 		CA4544A625E28D5E00665DF3 /* ToDoListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoListView.swift; sourceTree = "<group>"; };
 		CA4544AD25E28E9500665DF3 /* ToDoDetailCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoDetailCell.swift; sourceTree = "<group>"; };
 		CA4544B325E28F7600665DF3 /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
@@ -128,6 +134,7 @@
 		CA1F20AE25DAB83700B21B56 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				CA3E2B0325E90A980040083F /* Shape */,
 				CA25AEFB25DC013300A19DE6 /* Views */,
 				CA1F210E25DAC30400B21B56 /* Extension */,
 				CA1F20B125DAB83700B21B56 /* ToDoApp_SwiftUIApp.swift */,
@@ -190,6 +197,7 @@
 			children = (
 				CA1F210F25DAC31B00B21B56 /* ToDoEntity.swift */,
 				CA4544B325E28F7600665DF3 /* Binding.swift */,
+				CA3E2B0E25E90B280040083F /* Date.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -216,11 +224,20 @@
 			path = Category;
 			sourceTree = "<group>";
 		};
+		CA3E2B0325E90A980040083F /* Shape */ = {
+			isa = PBXGroup;
+			children = (
+				CA3E2B0425E90ACE0040083F /* RoundedCorners.swift */,
+			);
+			path = Shape;
+			sourceTree = "<group>";
+		};
 		CA4544AC25E28DFB00665DF3 /* ToDoList */ = {
 			isa = PBXGroup;
 			children = (
 				CA4544A625E28D5E00665DF3 /* ToDoListView.swift */,
 				CA4544AD25E28E9500665DF3 /* ToDoDetailCell.swift */,
+				CA3E2AFD25E90A6E0040083F /* TodayToDoListView.swift */,
 			);
 			path = ToDoList;
 			sourceTree = "<group>";
@@ -391,14 +408,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CA3E2AFE25E90A6E0040083F /* TodayToDoListView.swift in Sources */,
 				CA1F211025DAC31B00B21B56 /* ToDoEntity.swift in Sources */,
 				CA1F20DB25DAB83800B21B56 /* ToDoApp_SwiftUI.xcdatamodeld in Sources */,
 				CA25AEFD25DC018600A19DE6 /* CheckBox.swift in Sources */,
 				CA1F20E125DAB83800B21B56 /* Persistence.swift in Sources */,
 				CA1F20DD25DAB83800B21B56 /* ToDoApp_SwiftUIApp.swift in Sources */,
 				CA1F20DF25DAB83800B21B56 /* ContentView.swift in Sources */,
+				CA3E2B0F25E90B280040083F /* Date.swift in Sources */,
 				CA1CC70425DE9AD400BA1AD7 /* UserView.swift in Sources */,
 				CA4544B425E28F7600665DF3 /* Binding.swift in Sources */,
+				CA3E2B0525E90ACE0040083F /* RoundedCorners.swift in Sources */,
 				CAAD735125E7D7590063BD12 /* NewTaskView.swift in Sources */,
 				CAAD736125E7D9710063BD12 /* EditTaskView.swift in Sources */,
 				CA4544A725E28D5E00665DF3 /* ToDoListView.swift in Sources */,


### PR DESCRIPTION
## 概要

アプリトップに表示する当日のタスク一覧を表示するViewを作成する

## 理由/目的

当日のタスク一覧を可視化して、タスク管理の利便性を上げるため

## スクリーンキャプチャ

なし

## 関連ドキュメント

なし

## 動作確認/テスト

PreviewProviderでの表示の確認

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
